### PR TITLE
chore: tidy go module dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/basgys/goxml2json v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/tidwall/gjson v1.17.0
+	golang.org/x/crypto v0.18.0
 )
 
 require (

--- a/replace.go
+++ b/replace.go
@@ -7,7 +7,6 @@ import (
 	"crypto/des"
 	"crypto/hmac"
 	"crypto/md5"
-	"crypto/pbkdf2"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"
@@ -30,6 +29,7 @@ import (
 	"github.com/andreburgaud/crypt2go/padding"
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
+	"golang.org/x/crypto/pbkdf2"
 
 	cr "github.com/asyrafduyshart/templatereq/cryptography"
 	xj "github.com/basgys/goxml2json"
@@ -418,17 +418,13 @@ func funcPbkdf2(password string, salt string) string {
 		salt = arr[1]
 	}
 
-	hash, err := pbkdf2.Key(
-		sha512.New,
-		password,
+	hash := pbkdf2.Key(
+		[]byte(password),
 		[]byte(salt),
 		1000,
 		64,
+		sha512.New,
 	)
-
-	if err != nil {
-		return err.Error()
-	}
 
 	return base64.StdEncoding.EncodeToString(hash)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `golang.org/x/crypto` as a direct Go module dependency for PBKDF2 usage
- Switch PBKDF2 implementation to the `x/crypto` package so the module remains compatible with its `go 1.21` directive
- Run `go mod tidy` with no `go.sum` changes needed

## Verification
- `go vet ./...`
- `go test ./...`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ae149cd-c58d-4fac-b3bd-37cbfce2e7f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ae149cd-c58d-4fac-b3bd-37cbfce2e7f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

